### PR TITLE
Remove usage of pip internals from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,5 @@
 from setuptools import setup
-from pip.req import parse_requirements
-from pip.download import PipSession
 
-install_reqs = parse_requirements(
-    'requirements/main.txt', session=PipSession())
-reqs = [str(ir.req) for ir in install_reqs]
 
 setup(
     name='txes2',
@@ -18,7 +13,7 @@ setup(
     packages=['txes2'],
     include_package_data=True,
     zip_safe=False,
-    install_requires=reqs,
+    install_requires=['Twisted', 'anyjson', 'treq'],
     classifiers=[
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python',


### PR DESCRIPTION
I have removed the usage of pip internals from setup.py.

This does not work with certain versions of pip, [is not supported by the pip authors](https://github.com/racker/rackspace-monitoring-cli/pull/76#issuecomment-68302540) and in general a [bad idea](https://caremad.io/2013/07/setup-vs-requirement/) because `setup_requires` and `requirements.txt` serve different purposes.
