### PR TITLE
Dont include master only nodes in discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ _trial_temp
 build/
 dist/
 *.egg-info/
+.idea/

--- a/tests/test_elasticsearch.py
+++ b/tests/test_elasticsearch.py
@@ -1,7 +1,6 @@
 """Tests for the ElasticSearch class."""
 
 import uuid
-from txes2 import utils
 import os
 from mock import Mock
 
@@ -459,9 +458,11 @@ class ElasticSearchTest(TestCase):
                  'node-1': {'http_address': 'inet[/10.0.0.1:9200]'},
                  'node-2': {'http_address': 'inet[/10.0.0.2:9200]'},
                  'master-1': {'http_address': 'inet[/10.0.0.3:9200]',
-                              'attributes': {'data': 'false', 'master': 'true'}},
+                              'attributes':
+                                  {'data': 'false', 'master': 'true'}},
                  'master-2': {'http_address': 'inet[/10.0.0.4:9200]',
-                              'attributes': {'data': 'false', 'master': 'true'}},
+                              'attributes':
+                                  {'data': 'false', 'master': 'true'}},
              }})
         yield self.es._perform_discovery()
         self.assertTrue(len(self.es.connection.servers) == 4)

--- a/tests/test_elasticsearch.py
+++ b/tests/test_elasticsearch.py
@@ -459,9 +459,12 @@ class ElasticSearchTest(TestCase):
             {'cluster_name': 'test',
              'nodes': {
                  'node-1': {'http_address': 'inet[/10.0.0.1:9200]'},
-                 'node-2': {'http_address': 'inet[/10.0.0.2:9200]', 'data': 'true', 'master': 'false'},
-                 'master-1': {'http_address': 'inet[/10.0.0.3:9200]', 'data': 'false', 'master': 'true'},
-                 'master-2': {'http_address': 'inet[/10.0.0.4:9200]', 'data': 'false', 'master': 'true'},
+                 'node-2': {'http_address': 'inet[/10.0.0.2:9200]',
+                            'data': 'true', 'master': 'false'},
+                 'master-1': {'http_address': 'inet[/10.0.0.3:9200]',
+                              'data': 'false', 'master': 'true'},
+                 'master-2': {'http_address': 'inet[/10.0.0.4:9200]',
+                              'data': 'false', 'master': 'true'},
              }})
         yield self.es._perform_discovery()
         self.assertTrue(len(self.es.connection.servers) == 2)

--- a/tests/test_elasticsearch.py
+++ b/tests/test_elasticsearch.py
@@ -440,7 +440,6 @@ class ElasticSearchTest(TestCase):
 
     @inlineCallbacks
     def test_perform_discovery(self):
-        self.es.connection.servers = utils.ServerList([])
         self.es.cluster_nodes = Mock()
         self.es.cluster_nodes.return_value = succeed(
             {'cluster_name': 'test',
@@ -449,25 +448,23 @@ class ElasticSearchTest(TestCase):
                  'node-2': {'http_address': 'inet[/10.0.0.2:9200]'},
              }})
         yield self.es._perform_discovery()
-        self.assertTrue(len(self.es.connection.servers) == 2)
+        self.assertTrue(len(self.es.connection.servers) == 4)
 
     @inlineCallbacks
     def test_perform_discovery_with_master_only_nodes(self):
-        self.es.connection.servers = utils.ServerList([])
         self.es.cluster_nodes = Mock()
         self.es.cluster_nodes.return_value = succeed(
             {'cluster_name': 'test',
              'nodes': {
                  'node-1': {'http_address': 'inet[/10.0.0.1:9200]'},
-                 'node-2': {'http_address': 'inet[/10.0.0.2:9200]',
-                            'data': 'true', 'master': 'false'},
+                 'node-2': {'http_address': 'inet[/10.0.0.2:9200]'},
                  'master-1': {'http_address': 'inet[/10.0.0.3:9200]',
-                              'data': 'false', 'master': 'true'},
+                              'attributes': {'data': 'false', 'master': 'true'}},
                  'master-2': {'http_address': 'inet[/10.0.0.4:9200]',
-                              'data': 'false', 'master': 'true'},
+                              'attributes': {'data': 'false', 'master': 'true'}},
              }})
         yield self.es._perform_discovery()
-        self.assertTrue(len(self.es.connection.servers) == 2)
+        self.assertTrue(len(self.es.connection.servers) == 4)
 
     @inlineCallbacks
     def test_put_mapping(self):

--- a/txes2/elasticsearch.py
+++ b/txes2/elasticsearch.py
@@ -70,7 +70,7 @@ class ElasticSearch(object):
                 # Ignore master nodes
                 if (data_node.get('data', 'true') == 'false' and
                     data_node.get('client', 'false') == 'false' and
-                    data_node.get('master', 'true') == 'true'):
+                        data_node.get('master', 'true') == 'true'):
                         continue
 
                 server = http_addr.strip('inet[/]')

--- a/txes2/elasticsearch.py
+++ b/txes2/elasticsearch.py
@@ -68,9 +68,10 @@ class ElasticSearch(object):
                 if not http_addr:
                     continue
                 # Ignore master nodes
-                if (data_node.get('data', 'true') == 'false' and
-                    data_node.get('client', 'false') == 'false' and
-                        data_node.get('master', 'true') == 'true'):
+                attrs = data_node.get('attributes', {})
+                if (attrs.get('data', 'true') == 'false' and
+                    attrs.get('client', 'false') == 'false' and
+                        attrs.get('master', 'true') == 'true'):
                         continue
 
                 server = http_addr.strip('inet[/]')

--- a/txes2/elasticsearch.py
+++ b/txes2/elasticsearch.py
@@ -63,9 +63,15 @@ class ElasticSearch(object):
         def cb(data):
             self.cluster_name = data['cluster_name']
             for node in data['nodes']:
-                http_addr = data['nodes'][node].get('http_address')
+                data_node = data['nodes'][node]
+                http_addr = data_node.get('http_address')
                 if not http_addr:
                     continue
+                # Ignore master nodes
+                if (data_node.get('data', 'true') == 'false' and
+                    data_node.get('client', 'false') == 'false' and
+                    data_node.get('master', 'true') == 'true'):
+                        continue
 
                 server = http_addr.strip('inet[/]')
                 self.connection.add_server(server)


### PR DESCRIPTION
Its a common patter to run master only nodes (handle no data, no traffic request, just master work).  The current discovery logic will include all nodes in your cluster, including the master only nodes.  

This code models what the official lib does: https://github.com/elastic/elasticsearch-py/blob/master/elasticsearch/transport.py#L11
