### PR TITLE
Add _routing param to documents in bulk request

### DIFF
--- a/txes2/elasticsearch.py
+++ b/txes2/elasticsearch.py
@@ -482,6 +482,8 @@ class ElasticSearch(object):
                 cmd[optype]['_version'] = version
             if id:
                 cmd[optype]['_id'] = id
+            if 'routing' in query_params:
+                cmd[optype]['_routing'] = query_params['routing']
             data = '\n'.join([anyjson.serialize(cmd),
                               anyjson.serialize(doc)])
             data += '\n'


### PR DESCRIPTION
ES supports routing in bulk requests, but it should be added directly to each document instead of query string param in regular indexing.
